### PR TITLE
Use current Talk url scheme for identifying lotus tab

### DIFF
--- a/app/javascripts/modules/url_match.js
+++ b/app/javascripts/modules/url_match.js
@@ -2,7 +2,7 @@ var browser = require('./browser.js');
 
 var urlMatch = {
 
-  LOTUS_ROUTE: /^https?:\/\/(.*).zendesk.com\/agent\/(?!chat|voice)\#?\/?(.*)$/,
+  LOTUS_ROUTE: /^https?:\/\/(.*).zendesk.com\/agent\/(?!chat|talk)\#?\/?(.*)$/,
   TICKET_ROUTE: /^https?:\/\/(.*).zendesk.com\/(?:agent\/tickets|tickets|twickets|requests|hc\/requests)\#?\/?(.*)$/,
   RESTRICTED_ROUTE: /^https?:\/\/(.*).zendesk.com\/(agent\/(chat|talk|admin\/voice)\/?(.*)|tickets\/\d*\/print)/,
 


### PR DESCRIPTION
Zendesk stores the Talk dashboard at the /agent/talk address now, which will not handle ticket and other URL opens, with other Talk integrations directly happening within the agent dashboard on Support. This fixes an issue where browser.js's openRouteInZendesk() could encounter a tab with the Talk dashboard loaded at https://*.zendesk.com/agent/talk and attempt to open the ticket link here, then immediately close the originally opened tab making it appear as though nothing happened when the link was clicked.